### PR TITLE
Integrate MercadoPago payments

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,9 @@
+# MercadoPago Credentials
+NEXT_PUBLIC_MERCADOPAGO_PUBLIC_KEY=YOUR_PUBLIC_KEY_HERE
+MERCADOPAGO_ACCESS_TOKEN=YOUR_ACCESS_TOKEN_HERE
+
+# Authentication Secret
+NEXTAUTH_SECRET=your-secret-key
+
+# Application URL
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/app/api/mercadopago/webhook/route.ts
+++ b/app/api/mercadopago/webhook/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import mercadopago from 'mercadopago';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    console.log('MercadoPago webhook received:', body);
+
+    if (body.type === 'payment' && body.data?.id) {
+      if (process.env.MERCADOPAGO_ACCESS_TOKEN) {
+        mercadopago.configure({ access_token: process.env.MERCADOPAGO_ACCESS_TOKEN });
+        const payment = await mercadopago.payment.findById(body.data.id);
+        console.log('Payment status:', payment.body.status);
+      } else {
+        console.warn('MERCADOPAGO_ACCESS_TOKEN not configured');
+      }
+    }
+
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    console.error('Error processing webhook:', error);
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const type = searchParams.get('type') || searchParams.get('topic');
+    const id = searchParams.get('data.id') || searchParams.get('id');
+
+    if (type === 'payment' && id && process.env.MERCADOPAGO_ACCESS_TOKEN) {
+      mercadopago.configure({ access_token: process.env.MERCADOPAGO_ACCESS_TOKEN });
+      const payment = await mercadopago.payment.findById(Number(id));
+      console.log('Payment status (GET):', payment.body.status);
+    }
+
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    console.error('Error processing webhook:', error);
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/payment-status/route.ts
+++ b/app/api/payment-status/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import mercadopago from 'mercadopago';
 
 export async function GET(request: NextRequest) {
   try {
@@ -12,21 +13,20 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Mock payment status - In production, you would fetch from MercadoPago API
-    const mockPaymentData = {
-      id: paymentId,
-      status: 'approved',
-      transaction_amount: 85000,
-      currency_id: 'ARS',
-      payment_method_id: 'visa',
-      payer: {
-        email: 'customer@example.com'
-      },
-      date_created: new Date().toISOString(),
-      date_approved: new Date().toISOString()
-    };
+    if (!process.env.MERCADOPAGO_ACCESS_TOKEN) {
+      return NextResponse.json(
+        { message: 'MercadoPago access token not configured' },
+        { status: 500 }
+      );
+    }
 
-    return NextResponse.json(mockPaymentData);
+    mercadopago.configure({
+      access_token: process.env.MERCADOPAGO_ACCESS_TOKEN,
+    });
+
+    const payment = await mercadopago.payment.findById(Number(paymentId));
+
+    return NextResponse.json(payment.body);
   } catch (error) {
     console.error('Error fetching payment status:', error);
     return NextResponse.json(

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -34,6 +34,7 @@ export default function CartPage() {
         body: JSON.stringify({
           items: items.map(item => ({
             id: item.product.id,
+            title: item.product.name,
             quantity: item.quantity,
             price: item.product.price,
           })),

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,7 +24,8 @@ export async function middleware(request: NextRequest) {
     pathname.startsWith('/api/categories') ||
     pathname.startsWith('/api/config') ||
     pathname.startsWith('/api/checkout') ||
-    pathname.startsWith('/api/payment-status')
+    pathname.startsWith('/api/payment-status') ||
+    pathname.startsWith('/api/mercadopago')
   ) {
     return NextResponse.next();
   }

--- a/types/mercadopago.d.ts
+++ b/types/mercadopago.d.ts
@@ -1,0 +1,1 @@
+declare module 'mercadopago';


### PR DESCRIPTION
## Summary
- integrate MercadoPago SDK in checkout API with request validation
- implement payment status endpoint and webhook handler
- add cart item titles, middleware bypass, and sample env file

## Testing
- `npm run lint`
- `yarn type-check`

------
https://chatgpt.com/codex/tasks/task_e_68b0d8810c808327870254a75916fd72