### PR TITLE
Handle empty store name and show loading placeholder

### DIFF
--- a/app/config/page.tsx
+++ b/app/config/page.tsx
@@ -12,8 +12,8 @@ import toast from 'react-hot-toast';
 export default function ConfigPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
-  const { config, updateConfig } = useConfig();
-  const [storeName, setStoreName] = useState(config.storeName);
+  const { config, updateConfig, loading: configLoading } = useConfig();
+  const [storeName, setStoreName] = useState('');
   const [primaryColor, setPrimaryColor] = useState(config.primaryColor);
   const [secondaryColor, setSecondaryColor] = useState(config.secondaryColor);
   const [accentColor, setAccentColor] = useState(config.accentColor);
@@ -29,6 +29,12 @@ export default function ConfigPage() {
       return;
     }
   }, [user, loading, router]);
+
+  useEffect(() => {
+    if (!configLoading) {
+      setStoreName(config.storeName);
+    }
+  }, [config.storeName, configLoading]);
 
   const handleLogoUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -20,7 +20,8 @@ type LoginForm = z.infer<typeof loginSchema>;
 export default function LoginPage() {
   const router = useRouter();
   const { login } = useAuth();
-  const { config } = useConfig();
+  const { config, loading: configLoading } = useConfig();
+  const storeName = configLoading ? 'Cargando...' : config.storeName;
 
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -67,20 +68,20 @@ export default function LoginPage() {
             className="inline-flex items-center mb-6 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
           >
             <ArrowLeft className="h-4 w-4 mr-2" />
-            Volver a {config?.storeName ?? 'Inicio'}
+            Volver a {storeName || 'Inicio'}
           </button>
 
           {config?.logo && (
             <img
               className="mx-auto h-16 w-auto mb-6"
               src={config.logo}
-              alt={config?.storeName ?? 'Logo'}
+              alt={storeName || 'Logo'}
             />
           )}
 
           <h2 className="text-3xl font-bold mb-2">Iniciar Sesión</h2>
           <p className="text-gray-700 dark:text-gray-300">
-            Accede a tu cuenta en {config?.storeName ?? 'la tienda'}
+            Accede a tu cuenta en {storeName || 'la tienda'}
           </p>
         </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,8 @@ export default function HomePage() {
   const router = useRouter();
   const { user } = useAuth();
   const { addToCart } = useCart();
-  const { config } = useConfig();
+  const { config, loading: configLoading } = useConfig();
+  const storeName = configLoading ? 'Cargando...' : config.storeName;
 
   const [featuredProducts, setFeaturedProducts] = useState<Product[]>([]);
   const [allProducts, setAllProducts] = useState<Product[]>([]);
@@ -134,7 +135,7 @@ export default function HomePage() {
   <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full">
     <div className="text-center">
       <h1 className="text-4xl md:text-6xl font-bold mb-6 text-gray-900 dark:text-white">
-        Bienvenido a {config?.storeName ?? 'Nuestra Tienda'}
+        Bienvenido a {storeName || 'Nuestra Tienda'}
       </h1>
       <p className="text-xl md:text-2xl text-gray-700 dark:text-gray-300 max-w-2xl mx-auto">
         Encuentra todo lo que necesitas para tus proyectos

--- a/components/AdminLayout.tsx
+++ b/components/AdminLayout.tsx
@@ -25,7 +25,7 @@ interface AdminLayoutProps {
 export default function AdminLayout({ children }: AdminLayoutProps) {
   const router = useRouter();
   const { user, logout } = useAuth();
-  const { config } = useConfig();
+  const { config, loading: configLoading } = useConfig();
   const { theme, setTheme } = useTheme();
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const [mounted, setMounted] = useState(false);
@@ -57,13 +57,13 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
               {config.logo && (
                 <img
                   src={config.logo}
-                  alt={config.storeName}
+                  alt={config.storeName || 'Logo'}
                   className="h-8 w-8 object-contain"
                 />
               )}
               {isSidebarOpen && (
                 <span className="text-lg font-bold text-gray-900 dark:text-white">
-                  {config.storeName}
+                  {configLoading ? 'Cargando...' : config.storeName || ''}
                 </span>
               )}
             </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -4,7 +4,8 @@ import { useConfig } from '@/hooks/useConfig';
 import { Facebook, Twitter, Instagram, Mail, Phone, MapPin } from 'lucide-react';
 
 export default function Footer() {
-  const { config } = useConfig();
+  const { config, loading } = useConfig();
+  const storeName = loading ? 'Cargando...' : config.storeName || '';
 
   return (
     <footer className="bg-gray-900 text-white">
@@ -16,11 +17,11 @@ export default function Footer() {
               {config.logo && (
                 <img
                   src={config.logo}
-                  alt={config.storeName}
+                  alt={config.storeName || 'Logo'}
                   className="h-8 w-8 object-contain"
                 />
               )}
-              <span className="text-xl font-bold">{config.storeName}</span>
+              <span className="text-xl font-bold">{storeName}</span>
             </div>
             <p className="text-gray-400">
               Tu ferretería de confianza con más de 20 años de experiencia 
@@ -138,7 +139,7 @@ export default function Footer() {
 
         <div className="border-t border-gray-800 mt-8 pt-8 text-center">
           <p className="text-gray-400">
-            © 2024 {config.storeName}. Todos los derechos reservados.
+            © 2024{storeName ? ` ${storeName}.` : ''} Todos los derechos reservados.
           </p>
         </div>
       </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -22,7 +22,7 @@ import {
 export default function Header() {
   const router = useRouter();
   const { user, logout } = useAuth();
-  const { config } = useConfig();
+  const { config, loading } = useConfig();
   const { getItemCount } = useCart();
   const { theme, setTheme } = useTheme();
 
@@ -115,12 +115,12 @@ export default function Header() {
                 // Mantengo <img> para no requerir domain config de next/image
                 <img
                   src={config.logo}
-                  alt={config?.storeName ?? 'Tienda'}
+                  alt={config.storeName || 'Logo'}
                   className="h-8 w-8 object-contain"
                 />
               )}
               <span className="text-xl font-bold text-gray-900 dark:text-white">
-                {config?.storeName ?? 'Mi Tienda'}
+                {loading ? 'Cargando...' : config.storeName || ''}
               </span>
             </button>
           </div>

--- a/contexts/ConfigContext.tsx
+++ b/contexts/ConfigContext.tsx
@@ -10,7 +10,7 @@ interface ConfigContextType {
 }
 
 const defaultConfig: StoreConfig = {
-  storeName: 'Aguante Boca',
+  storeName: '',
   logo: '',
   primaryColor: '#204a87',
   secondaryColor: '#c4a000',


### PR DESCRIPTION
## Summary
- avoid initial flash by using an empty default store name
- display "Cargando..." until store configuration loads across UI
- sync admin config page with loaded store name

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b1e5d1b334832787e76b9b49eec2c4